### PR TITLE
Update README.asc

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -8,9 +8,7 @@ Wydanie drugie tak jak wydanie pierwsze udostępniane jest na licencji Creative
 Commons.
 
 Zmieniono kilka rzeczy od czasu pierwszego wydania. Po pierwsze, przenieśliśmy
-tekst książki z Markdown do wspaniałego formatu Asciidoc. Używamy też
-https://atlas.oreilly.com[Platformy atlas] od O'Reilly do generacji ciągłych
-wersji książki, więc główne formaty są zawsze dostępne w każdym języku.
+tekst książki z Markdown do wspaniałego formatu Asciidoc.
 
 Przenieśliśmy tłumaczenenia do oddzielnych repozytoriów zamiast podkatalogów w
 angielskim repozytorium. Zajrzyj do link:CONTRIBUTING.md[przewodnika] po wiecej informacji.
@@ -22,8 +20,7 @@ Są dwa sposoby na wygenerowanie zawartości e-book'a z tego kodu źródłowego.
 Najłatwiej powierzyć to nam. Robot czeka na nowe zmiany w głównej gałęzi i
 dokonuje automatycznej budowy dla wszystkich.
 
-Możesz znaleźć aktualne wersje tutaj: http://git-scm.com/book[] wiecej
-informacji o wersjach tutaj https://progit.org[].
+Aktualną wersję znajdziesz tutaj: https://git-scm.com/book[].
 
 Innym sposobem jest ręczna budowa za pomocą Asciidoctor. Po uruchomieniu
 poniższych poleceń możesz uzyskać pliki wyjściowe w formatach HTML, Epub, Mobi


### PR DESCRIPTION
- Atlas references removed
- removed obsolete link progit.org
- changed to secure link https://

As per the current state of the main project, ie https://github.com/progit/progit2/blob/main/README.asc.